### PR TITLE
Update vmware version in attributes file.

### DIFF
--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -31,7 +31,7 @@
 :kube_version: 1.16.2
 :kubedoc: https://kubernetes.io/docs/home/
 :kured_version: 1.2.0-rev4
-:vmware_version: 6.7.0.20000
+:vmware_version: 6.7
 :helm_tiller_version: 2.15.0
 
 // API versions


### PR DESCRIPTION
Based on [VMware documentation](https://www.vmware.com/resources/compatibility/search.php?deviceCategory=software&details=1&operatingSystems=247&productNames=15&page=1&display_interval=10&sortColumn=Partner&sortOrder=Asc&testConfig=16), SLES 15 should be only compatible with VMware ESXi 6.7. Confirmed [with QA](https://chat.suse.de/channel/caasp-qa?msg=amvXnjnzEZsf6yRvT) and PM. 