### PR TITLE
Remove "\"

### DIFF
--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -251,9 +251,7 @@ Core addons are addons deployed automatically by `skuba` when you bootstrap a cl
 The gangway image that shipped with {productname} 4.0 must be updated manually by performing the following step:
 
 ====
-kubectl set image deployment/oidc-gangway \
-    oidc-gangway=registry.suse.com/caasp/v4/gangway:3.1.0-rev4 \
-    --namespace kube-system
+kubectl set image deployment/oidc-gangway oidc-gangway=registry.suse.com/caasp/v4/gangway:3.1.0-rev4 --namespace kube-system
 ====
 
 == Known Issues


### PR DESCRIPTION
Remove the "\", because this cause the doc rendering command not working.

Signed-off-by: JenTing Hsiao <jenting.hsiao@suse.com>