### PR TITLE
Add section about AWS deployment as technology preview.

### DIFF
--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -28,7 +28,7 @@ Deployment of {productname} on Amazon Web Services (AWS) has been tested and doc
 For detailed instructions please see link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#_deployment_on_amazon_aws[the Deployment Guide].
 Please note that {productname} deployment on AWS may not be functionally complete, and is not intended for production use.
 
-=== Terraform Upgarde
+=== Terraform Upgrade
 {productname} can now be deployed with *{tf} 0.12*. All details of the new version
 can be found in the link:https://www.hashicorp.com/blog/terraform-0-1-2-preview/[HashiCorp Documentation].
 The official website for the {tf} 0.12 upgrade is https://www.terraform.io/upgrade-guides/0-12.html.

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -21,6 +21,14 @@ To make such entries easier to identify, they contain a note to that effect.
 
 == Changes in 4.1.2
 
+=== Deployment on AWS as Technology Preview
+
+Deployment of {productname} on Amazon Web Services (AWS) has been tested and documented.
+{tf} is used to deploy the infrastructure and the `skuba` tool to bootstrap the {kube} cluster on top of it.
+For detailed instructions please see link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#_deployment_on_amazon_aws[the Deployment Guide].
+Please note that {productname} deployment on AWS may not be functionally complete, and is not intended for production use.
+
+=== Terraform Upgarde
 {productname} can now be deployed with *{tf} 0.12*. All details of the new version
 can be found in the link:https://www.hashicorp.com/blog/terraform-0-1-2-preview/[HashiCorp Documentation].
 The official website for the {tf} 0.12 upgrade is https://www.terraform.io/upgrade-guides/0-12.html.


### PR DESCRIPTION
This section describes that we have now tested and documented the AWS deployment option and links to the relevant documentation section. 
Should be released in 4.1.2.
Relates to: https://github.com/SUSE/doc-caasp/pull/541
