### PR TITLE
Add note about terraform output nullstrings after update

### DIFF
--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -57,9 +57,12 @@ need to update your {tf} files (and states) in place for {tf} 0.12.
 
 To do this, enter your {tf} files/state folder and:
 
+* Install the latest version of {tf} using `zypper in terraform` (the installed version should be 0.12.19)
+* Navigate to your {tf} root folder (e.g. `/usr/share/caasp/terraform/vmware`)
 * Migrate {tf} files with the automatic migration tool by running `terraform 0.12upgrade`.
-* For OpenStack, run the extra operations for in-place upgrade, which follow just below.
-* For VMware, there is no extra operation.
+** For OpenStack, run the extra operations for in-place upgrade, which follow just below.
+** For VMware, there is no extra operation but please note <<vmware_precaution_nullstrings>>.
+* Run `zypper up skuba`
 * You can then run the `terraform init/plan/apply` commands as usual.
 
 ==== Extra Operations for In-place Upgrade of OpenStack {tf} Files
@@ -110,6 +113,7 @@ SUSE update the `user_data`. This should be removed as soon as possible after th
 migration to {tf} 0.12.
 =========
 
+[[vmware_precaution_nullstrings]]
 ==== Extra precautions for automations based on `output.tf` on VMWare
 
 If you are running any automations on your VMWare deployment of {productname} that

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -29,6 +29,7 @@ For detailed instructions please see link:https://documentation.suse.com/suse-ca
 Please note that {productname} deployment on AWS may not be functionally complete, and is not intended for production use.
 
 === Terraform Upgrade
+
 {productname} can now be deployed with *{tf} 0.12*. All details of the new version
 can be found in the link:https://www.hashicorp.com/blog/terraform-0-1-2-preview/[HashiCorp Documentation].
 The official website for the {tf} 0.12 upgrade is https://www.terraform.io/upgrade-guides/0-12.html.
@@ -41,7 +42,7 @@ Add CLI etcdctl to provide access to etcd container.
 In order to seamlessly switch to {tf} 0.12 you need to make sure that:
 
 * all files follow the new syntax for the HashiCorp Configuration Language included in {tf} 0.12;
-* all boolean values are ``true`` or ``false`` and *not* 0 or 1;
+* all boolean values are `true` or `false` and *not* 0 or 1;
 * all variables are explicitly declared;
 * all dependencies are explicitly declared to reach the expected behavior.
 
@@ -56,26 +57,26 @@ need to update your {tf} files (and states) in place for {tf} 0.12.
 
 To do this, enter your {tf} files/state folder and:
 
-* Migrate {tf} files with the automatic migration tool by running ``terraform 0.12upgrade``.
+* Migrate {tf} files with the automatic migration tool by running `terraform 0.12upgrade`.
 * For OpenStack, run the extra operations for in-place upgrade, which follow just below.
 * For VMware, there is no extra operation.
-* You can then run the ``terraform init/plan/apply`` commands as usual.
+* You can then run the `terraform init/plan/apply` commands as usual.
 
 ==== Extra Operations for In-place Upgrade of OpenStack {tf} Files
 
-* Replace any boolean values written as a number with ``false``/``true``.
-  For example, for the variables in ``openstack/variables.tf``
-  (and their equivalent in your ``terraform.tfvars`` file), replace
-  ``default = 0`` with ``default = false`` in the variables
-  ``workers_vol_enabled`` and ``dnsentry``. Do the same for
+* Replace any boolean values written as a number with `false`/`true`.
+  For example, for the variables in `openstack/variables.tf`
+  (and their equivalent in your `terraform.tfvars` file), replace
+  `default = 0` with `default = false` in the variables
+  `workers_vol_enabled` and `dnsentry`. Do the same for
   any extra boolean variable you might have added.
-* Introduce a ``depends_on`` on the resource ``"openstack_compute_floatingip_associate_v2" "master_ext_ip"`` in ``master-instance.tf``:
+* Introduce a `depends_on` on the resource `"openstack_compute_floatingip_associate_v2" "master_ext_ip"` in `master-instance.tf`:
 +
 ----
 depends_on = [openstack_compute_instance_v2.master]
 ----
 +
-* Introduce a ``depends_on`` on the resource ``"master_wait_cloudinit"`` in ``master-instance.tf``:
+* Introduce a `depends_on` on the resource `"master_wait_cloudinit"` in `master-instance.tf`:
 +
 ----
 depends_on = [
@@ -84,13 +85,13 @@ depends_on = [
 ]
 ----
 +
-* Introduce a ``depends_on`` on the resources
-  ``"openstack_compute_floatingip_associate_v2" "worker_ext_ip"`` and
-  ``"null_resource" "worker_wait_cloudinit"`` in ``worker-instance.tf``, similarly to the ones for master.
-  Replace ``master`` with ``worker`` in the examples above.
-* Update the resources ``resource "openstack_compute_instance_v2" "master"``
-  and ``resource "openstack_compute_instance_v2" "worker"`` with
-  ``master-instance.tf`` and ``worker-instance.tf`` respectively. Add the following resources:
+* Introduce a `depends_on` on the resources
+  `"openstack_compute_floatingip_associate_v2" "worker_ext_ip"` and
+  `"null_resource" "worker_wait_cloudinit"` in `worker-instance.tf`, similarly to the ones for master.
+  Replace `master` with `worker` in the examples above.
+* Update the resources `resource "openstack_compute_instance_v2" "master"`
+  and `resource "openstack_compute_instance_v2" "worker"` with
+  `master-instance.tf` and `worker-instance.tf` respectively. Add the following resources:
 +
 ----
 lifecycle {
@@ -103,9 +104,9 @@ into a {tf} 0.12 state without tearing it down completely.
 
 [WARNING]
 =========
-When adding ``lifecycle { ignore_change = [user_data] }`` in your master and
+When adding `lifecycle { ignore_change = [user_data] }` in your master and
 worker instances, you will effectively prevent updates of nodes, should you or
-SUSE update the ``user_data``. This should be removed as soon as possible after the
+SUSE update the `user_data`. This should be removed as soon as possible after the
 migration to {tf} 0.12.
 =========
 
@@ -296,25 +297,25 @@ moved to different groups or deprecated.
 
 The following will impact your deployment manifests:
 
-*  ``DaemonSet``, ``Deployment``, ``StatefulSet``, and ``ReplicaSet`` in
-  ``extensions/`` (both ``v1beta1`` and ``v1beta2``) is deprecated.
-  Migrate to ``apps/v1`` group instead for all those objects.
-  Please note that ``kubectl convert`` can help you migrate all the
+*  `DaemonSet`, `Deployment`, `StatefulSet`, and `ReplicaSet` in
+  `extensions/` (both `v1beta1` and `v1beta2`) is deprecated.
+  Migrate to `apps/v1` group instead for all those objects.
+  Please note that `kubectl convert` can help you migrate all the
   necessary fields.
-*  ``PodSecurityPolicy`` in ``extensions/v1beta1`` is deprecated. Migrate to
-  ``policy/v1beta1`` group for ``PodSecurityPolicy``.
-  Please note that ``kubectl convert`` can help you migrate all the
+*  `PodSecurityPolicy` in `extensions/v1beta1` is deprecated. Migrate to
+  `policy/v1beta1` group for `PodSecurityPolicy`.
+  Please note that `kubectl convert` can help you migrate all the
   necessary fields.
-*  ``NetworkPolicy`` in ``extensions/v1beta1`` is deprecated. Migrate to
-  ``networking.k8s.io/v1`` group for ``NetworkPolicy``.
-  Please note that ``kubectl convert`` can help you migrate all the
+*  `NetworkPolicy` in `extensions/v1beta1` is deprecated. Migrate to
+  `networking.k8s.io/v1` group for `NetworkPolicy`.
+  Please note that `kubectl convert` can help you migrate all the
   necessary fields.
-*  ``Ingress`` in ``extensions/v1beta1`` is being phased out. Migrate to
-  ``networking.k8s.io/v1beta1`` as soon as possible.
+*  `Ingress` in `extensions/v1beta1` is being phased out. Migrate to
+  `networking.k8s.io/v1beta1` as soon as possible.
   This new API does not need to update other API fields and therefore
   only a path change is necessary.
-*  Custom resource definitions have moved from ``apiextensions.k8s.io/v1beta1``
-  to ``apiextensions.k8s.io/v1``.
+*  Custom resource definitions have moved from `apiextensions.k8s.io/v1beta1`
+  to `apiextensions.k8s.io/v1`.
 
 Please also see https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ for more details.
 

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -48,14 +48,7 @@ In order to seamlessly switch to {tf} 0.12 you need to make sure that:
 
 ==== Recommended Procedure
 
-If you can tear down your existing cluster, do delete your cluster
-before upgrading to {tf} 0.12. After that, follow our documentation to create a new cluster.
-That will lead to the cleanest upgrade result.
-
-If you are using {tf} 0.11 and you cannot tear down your cluster, you will
-need to update your {tf} files (and states) in place for {tf} 0.12.
-
-To do this, enter your {tf} files/state folder and:
+Enter your {tf} files/state folder and:
 
 * Install the latest version of {tf} using `zypper in terraform` (the installed version should be 0.12.19)
 * Navigate to your {tf} root folder (e.g. `/usr/share/caasp/terraform/vmware`)
@@ -108,6 +101,11 @@ lifecycle {
   ignore_changes = [user_data]
 }
 ----
++
+[NOTE]
+====
+The above option is needed because {tf} will detect all machines as new resources when `user_data` changes during the upgrade.
+====
 +
 This will make it possible to update your cluster from a {tf} 0.11 state
 into a {tf} 0.12 state without tearing it down completely.

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -109,6 +109,32 @@ SUSE update the ``user_data``. This should be removed as soon as possible after 
 migration to {tf} 0.12.
 =========
 
+==== Extra precautions for automations based on `output.tf` on VMWare
+
+If you are running any automations on your VMWare deployment of {productname} that
+relies on the {tf} output as defined in `output.tf`, you might encounter some `null` values in the value slice after
+the update to {tf} 0.12. For example:
+
+----
+Outputs:
+ip_load_balancer = [
+  "10.84.73.8",
+]
+ip_masters = [
+  [
+    null,
+  ],
+]
+ip_workers = [
+  [
+    null,
+  ],
+]
+----
+
+You can work around this problem by joining another node to the cluster once {tf} 0.12 is installed.
+
+
 === Bugs Fixed in 4.1.2 since 4.1.1
 
 * link:https://bugzilla.suse.com/show_bug.cgi?id=1161056[bsc#1161056] [cri-o] - Fix upgrade from 4.0.3 to 4.1.0 - skuba node upgrade - fails due to crio-wipe.service not starting

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -59,16 +59,14 @@ To do this, enter your {tf} files/state folder and:
 
 * Install the latest version of {tf} using `zypper in terraform` (the installed version should be 0.12.19)
 * Navigate to your {tf} root folder (e.g. `/usr/share/caasp/terraform/vmware`)
-* Migrate {tf} files with the automatic migration tool by running `terraform 0.12upgrade`.
-** For OpenStack, run the <<terraform-openstack-extra-ops>>
-** For VMware, run `terraform apply` to update the {tf} definitions to the new format used by 0.12.
+* Migrate {tf} files with the automatic migration tool by running `terraform 0.12upgrade`
+** For OpenStack, run the <<terraform-openstack-extra-ops>> (see below)
+** Run `terraform apply` to update the {tf} definitions to the new format used by 0.12
 +
 [IMPORTANT]
 ====
-This problem only exists on VMWare deployments.
-
-If you do not update the definitions before running {tf} again your output might contain `nil` or `null` strings where you would expect output strings.
-This can break automations based on the output. Please make sure you have updated/applied all definitions before running {tf}.
+If you do not update the definitions before running {tf} again your output might contain `nil`/`null` strings when you run `terraform refresh` followed by `terraform output`.
+This can break automations that are based on the output. Please make sure you have updated/applied all definitions before running {tf}.
 ====
 * Run `zypper up skuba`
 * You can then run the `terraform init/plan/apply` commands as usual.

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -41,15 +41,15 @@ Add CLI etcdctl to provide access to etcd container.
 
 In order to seamlessly switch to {tf} 0.12 you need to make sure that:
 
-* all files follow the new syntax for the HashiCorp Configuration Language included in {tf} 0.12;
-* all boolean values are `true` or `false` and *not* 0 or 1;
-* all variables are explicitly declared;
-* all dependencies are explicitly declared to reach the expected behavior.
+* All files follow the new syntax for the link:https://github.com/hashicorp/hcl[HashiCorp Configuration Language] included in {tf} 0.12
+* All boolean values are `true` or `false` and *not* 0 or 1
+* All variables are explicitly declared
+* All dependencies are explicitly declared to reach the expected behavior
 
 ==== Recommended Procedure
 
 If you can tear down your existing cluster, do delete your cluster
-before upgrading to {tf} 0.12. After that follow our documentation to create a new cluster.
+before upgrading to {tf} 0.12. After that, follow our documentation to create a new cluster.
 That will lead to the cleanest upgrade result.
 
 If you are using {tf} 0.11 and you cannot tear down your cluster, you will
@@ -60,11 +60,20 @@ To do this, enter your {tf} files/state folder and:
 * Install the latest version of {tf} using `zypper in terraform` (the installed version should be 0.12.19)
 * Navigate to your {tf} root folder (e.g. `/usr/share/caasp/terraform/vmware`)
 * Migrate {tf} files with the automatic migration tool by running `terraform 0.12upgrade`.
-** For OpenStack, run the extra operations for in-place upgrade, which follow just below.
-** For VMware, there is no extra operation but please note <<vmware_precaution_nullstrings>>.
+** For OpenStack, run the <<terraform-openstack-extra-ops>>
+** For VMware, run `terraform apply` to update the {tf} definitions to the new format used by 0.12.
++
+[IMPORTANT]
+====
+This problem only exists on VMWare deployments.
+
+If you do not update the definitions before running {tf} again your output might contain `nil` or `null` strings where you would expect output strings.
+This can break automations based on the output. Please make sure you have updated/applied all definitions before running {tf}.
+====
 * Run `zypper up skuba`
 * You can then run the `terraform init/plan/apply` commands as usual.
 
+[[terraform-openstack-extra-ops]]
 ==== Extra Operations for In-place Upgrade of OpenStack {tf} Files
 
 * Replace any boolean values written as a number with `false`/`true`.
@@ -112,33 +121,6 @@ worker instances, you will effectively prevent updates of nodes, should you or
 SUSE update the `user_data`. This should be removed as soon as possible after the
 migration to {tf} 0.12.
 =========
-
-[[vmware_precaution_nullstrings]]
-==== Extra precautions for automations based on `output.tf` on VMWare
-
-If you are running any automations on your VMWare deployment of {productname} that
-relies on the {tf} output as defined in `output.tf`, you might encounter some `null` values in the value slice after
-the update to {tf} 0.12. For example:
-
-----
-Outputs:
-ip_load_balancer = [
-  "10.84.73.8",
-]
-ip_masters = [
-  [
-    null,
-  ],
-]
-ip_workers = [
-  [
-    null,
-  ],
-]
-----
-
-You can work around this problem by joining another node to the cluster once {tf} 0.12 is installed.
-
 
 === Bugs Fixed in 4.1.2 since 4.1.1
 

--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -1,6 +1,6 @@
 // Release type, set this to either 'public' or 'internal'
 :release_type: public
-:current_year: 2019
+:current_year: 2020
 
 // Media Locations
 :docurl: https://documentation.suse.com/suse-caasp/4.1/
@@ -16,13 +16,13 @@
 //Counting upwards from 0, tied to kubernetes releases
 :productminor: 1
 //Counting upwards from 0, tied to maintenance release
-:productpatch: 1
+:productpatch: 2
 :prerelease:
 :productversion: {productmajor}.{productminor}.{productpatch}
 :github_url: https://github.com/SUSE/doc-caasp
 
 // Component Versions
-
+:base_os_version: 15 SP1
 :cilium_version: 1.5.3
 :envoy_version:
 :crio_version: 1.16.0
@@ -34,6 +34,8 @@
 :kured_version: 1.2.0-rev4
 :vmware_version: 6.7
 :helm_tiller_version: 2.16.1
+:terraform_version: 0.12
+:haproxy_version: 1.8.7
 
 // API versions
 


### PR DESCRIPTION
https://github.com/SUSE/avant-garde/issues/1113#issuecomment-588233725

When updating to tf 0.12 you can get `null` strings in the output. This can break automations. The current workaround proposed by @atighineanu is to add an additional node (which somehow fixes the output). This isn't really feasible when hardware isn't just a few clicks away.

Wording needs to reflect a proper solution or workaround needs to be approved by @kkaempf. 

EDIT: The current problem is that the workaround involves adding a node to have terraform "fix" the output through some unknown means. This is not really realistic to suggest to customers.

The cause of this should be investigated and resolved. We currently seem to have nobody on the engineering team with access to VMWare for testing.