### PR TITLE
Add the hyperkube removal


### DIFF
--- a/adoc/release=4.3.0
+++ b/adoc/release=4.3.0
@@ -1,0 +1,7 @@
+== Changes in 4.3.0
+
+=== Deprecations
+
+- The hyperkube image, combining multiple kubernetes binaries was removed
+  in this version. If running {productname} in an airgapped environment,
+  please ensure that all our images are mirrored.


### PR DESCRIPTION

Following up on 4.2.0 deprecation, this clarifies
that 4.3.0 will remove hyperkube.


