### PR TITLE
Integrate 5.0.0 changes into master

### DIFF
--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -21,6 +21,8 @@ To make such entries easier to identify, they contain a note to that effect.
 
 
 // Release specific files, latest on top!
+include::release-4.0.0.adoc[Release 5.0.0]
+
 include::release-4.2.1.adoc[Release 4.2.1]
 
 include::release-4.2.0.adoc[Release 4.2.0]

--- a/adoc/MAIN.release-notes.adoc
+++ b/adoc/MAIN.release-notes.adoc
@@ -21,7 +21,7 @@ To make such entries easier to identify, they contain a note to that effect.
 
 
 // Release specific files, latest on top!
-include::release-4.0.0.adoc[Release 5.0.0]
+include::release-5.0.0.adoc[Release 5.0.0]
 
 include::release-4.2.1.adoc[Release 4.2.1]
 

--- a/adoc/attributes.adoc
+++ b/adoc/attributes.adoc
@@ -5,11 +5,11 @@
 // Product Versions
 
 //Counting upwards from 4, tied to SLE15 releases
-:productmajor: 4
+:productmajor: 5
 //Counting upwards from 0, tied to kubernetes releases
-:productminor: 2
+:productminor: 0
 //Counting upwards from 0, tied to maintenance release
-:productpatch: 1
+:productpatch: 0
 :prerelease:
 :productversion: {productmajor}.{productminor}.{productpatch}
 :github_url: https://github.com/SUSE/doc-caasp

--- a/adoc/release-4.1.0.adoc
+++ b/adoc/release-4.1.0.adoc
@@ -75,7 +75,7 @@ Please, do not run `zypper patch` manually on your nodes.
 If you do, you will see an error about a conflict when patching {crio}.
 This is expected, because the patch is not supposed to be installed this way.
 
-Instead, cluster updates are being handled by skuba as link:{docurl}/single-html/caasp-admin/#handling_updates[documented in the Administration guide].
+Instead, cluster updates are being handled by skuba as link:https://documentation.suse.com/suse-caasp/single-html/caasp-admin/#handling_updates[documented in the Administration guide].
 ====
 
 ==== Update Your {kube} Manifests for {kube} {kube_version}:
@@ -125,16 +125,16 @@ Please also see https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/ 
 === Documentation Updates
 
 * Switched examples to use SUSE supported helm, Prometheus, nginx-ingress and Grafana charts and images
-* link:{docurl}caasp-admin/single-html/_security.html#_deployment_with_a_custom_ca_certificate[Added instructions on how to replace {kube} certificates with custom CA certificate]
-* link:{docurl}caasp-admin/single-html/_security.html#_replace_server_certificate_signed_by_a_trusted_ca_certificate[Added instructions to configure custom certificates for gangway and dex]
-* link:{docurl}caasp-admin/single-html/_software_management.html#_installing_tiller[Added instructions for secured Tiller deployment]
-* link:{docurl}caasp-deployment/single-html/#machine-id[Added notes about unique `machine-id` requirement]
-* link:{docurl}caasp-deployment/single-html/#_autoyast_preparation[Added timezone configuration example for {ay}]
+* link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/caasp-admin.html#_deployment_with_a_custom_ca_certificate[Added instructions on how to replace {kube} certificates with custom CA certificate]
+* link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/caasp-admin.html#_replace_server_certificate_signed_by_a_trusted_ca_certificate[Added instructions to configure custom certificates for gangway and dex]
+* link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/caasp-admin.html#_installing_tiller[Added instructions for secured Tiller deployment]
+* link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#machine-id[Added notes about unique `machine-id` requirement]
+* link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#_autoyast_preparation[Added timezone configuration example for {ay}]
 * link:https://github.com/SUSE/doc-caasp/pulls?q=is%3Apr+is%3Aclosed+sort%3Aupdated-desc[Various minor bugfixes and improvements]
 
 === Known Issues
 
-==== Skuba-upgrade could not parse "Unknown" as version 
+==== Skuba-upgrade could not parse "Unknown" as version
 
 Running "skuba node upgrade plan" might fail with the error "could not parse "Unknown" as version" when a worker, after running "skuba node upgrade apply", had not fully started yet.
 

--- a/adoc/release-4.1.1.adoc
+++ b/adoc/release-4.1.1.adoc
@@ -50,9 +50,9 @@ Afterwards you can deploy Prometheus as usual. Refer to: link:https://documentat
 [[docs-changes-411]]
 === Documentation Changes
 
-* Added instructions for link:{docurl}single-html/caasp-admin/#_stratos_web_console[Stratos Web Console (Tech Preview)]
-* Added instructions for link:{docurl}single-html/caasp-deployment/#_storage_performance[etcd storage performance testing]
-* Added instructions for link:{docurl}single-html/caasp-admin/#troubleshooting-etcd[`etcd` troubleshooting]
-* Updated link:{docurl}single-html/caasp-admin/#_configuring_httphttps_proxy_for_cri_o[{crio} proxy configuration instructions]
-* Updated upgrade instructions with more link:{docurl}/single-html/caasp-admin/#disabling_automatic_updates[information about manual upgrades and reboots]
+* Added instructions for link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#_stratos_web_console[Stratos Web Console (Tech Preview)]
+* Added instructions for link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#_storage_performance[etcd storage performance testing]
+* Added instructions for link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#troubleshooting-etcd[`etcd` troubleshooting]
+* Updated link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#_configuring_httphttps_proxy_for_cri_o[{crio} proxy configuration instructions]
+* Updated upgrade instructions with more link:https://documentation.suse.com/suse-caasp/4.1//single-html/caasp-admin/#disabling_automatic_updates[information about manual upgrades and reboots]
 * Various minor fixes and improvements (Refer to: https://github.com/SUSE/doc-caasp/releases)

--- a/adoc/release-4.1.2.adoc
+++ b/adoc/release-4.1.2.adoc
@@ -143,5 +143,5 @@ Packages on your cluster nodes (cri-o) will be updated automatically by `skuba-u
 * Added link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#deployment_bare_metal[KVM deployment instructions]
 * Improved instructions for Monitoring to link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#_monitoring_stack[deploy Grafana in a sub path] and enhanced ingress settings
 * Fix unspecific expression in link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#alertmanager_configuration_example[AlertManager example]
-* Added notes on link:single-html/caasp-admin/#_control_plane_nodes_certificates_rotation[certificate rotation for the control plane]
+* Added notes on link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#_control_plane_nodes_certificates_rotation[certificate rotation for the control plane]
 * Various other fixes and improvements (Refer to: https://github.com/SUSE/doc-caasp/releases)

--- a/adoc/release-4.1.2.adoc
+++ b/adoc/release-4.1.2.adoc
@@ -139,9 +139,9 @@ Packages on your cluster nodes (cri-o) will be updated automatically by `skuba-u
 [[docs-changes-412]]
 === Documentation Changes
 
-* Added link:{docurl}single-html/caasp-deployment/#_deployment_on_amazon_aws[AWS deployment instructions] (Tech Preview)
-* Added link:{docurl}single-html/caasp-deployment/#deployment_bare_metal[KVM deployment instructions]
-* Improved instructions for Monitoring to link:{docurl}single-html/caasp-admin/#_monitoring_stack[deploy Grafana in a sub path] and enhanced ingress settings
-* Fix unspecific expression in link:{docurl}single-html/caasp-admin/#alertmanager_configuration_example[AlertManager example]
+* Added link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#_deployment_on_amazon_web_services_aws[AWS deployment instructions] (Tech Preview)
+* Added link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-deployment/#deployment_bare_metal[KVM deployment instructions]
+* Improved instructions for Monitoring to link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#_monitoring_stack[deploy Grafana in a sub path] and enhanced ingress settings
+* Fix unspecific expression in link:https://documentation.suse.com/suse-caasp/4.1/single-html/caasp-admin/#alertmanager_configuration_example[AlertManager example]
 * Added notes on link:single-html/caasp-admin/#_control_plane_nodes_certificates_rotation[certificate rotation for the control plane]
 * Various other fixes and improvements (Refer to: https://github.com/SUSE/doc-caasp/releases)

--- a/adoc/release-4.2.0.adoc
+++ b/adoc/release-4.2.0.adoc
@@ -85,17 +85,17 @@ This will generate the existing addon configurations in the new format so you ca
 === Documentation Changes
 
 * The QuickStart Guide has been removed pending review and rewrite.
-Please use the link:{docurl}single-html/caasp-deployment/[Deployment Guide].
-* link:{docurl}single-html/caasp-admin/#_backup_and_restore_with_velero[Disaster Recovery with Velero] is now documented in the Admin Guide.
-* A link:{docurl}single-html/caasp-deployment/#_replicas[subchapter on Managing Replicas] has been added to Deployment Requirements.
-* The link:{docurl}single-html/caasp-deployment/#airgap-container_registry-mirror[list of required addon images] was updated.
+Please use the link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/[Deployment Guide].
+* link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_backup_and_restore_with_velero[Disaster Recovery with Velero] is now documented in the Admin Guide.
+* A link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#_replicas[subchapter on Managing Replicas] has been added to Deployment Requirements.
+* The link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#airgap-container_registry-mirror[list of required addon images] was updated.
 * {cap} integration was removed from the {productname} Admin Guide. Please now refer to: link:https://documentation.suse.com/suse-cap/{cap_version}/single-html/cap-guides/#cha-cap-depl-caasp[Deploying SUSE Cloud Application Platform on SUSE CaaS Platform].
-* A note about using the `--non-interactive-include-reboot-patches` was added to the link:{docurl}/single-html/caasp-admin/#disabling-automatic-updates[Admin Guide].
-* Instructions on how to update Dex have been enhanced. For details, see link:{docurl}single-html/caasp-admin/#_sec.admin.security.rbac.update[the Admin Guide].
-* We updated the air gapped deployment with a new diagram. See the link:{docurl}single-html/caasp-deployment/#airgap-concepts[Admin Guide].
-* We added an example on how to set up link:{docurl}single-html/caasp-admin/caasp-admin.html#recording_rules_configuration_example[Prometheus Recording Rules].
-* link:{docurl}single-html/caasp-admin/caasp-admin.html#_aws_deployment_fails_with_cannot_attach_profile_error[Instructions on how to troubleshoot the `"cannot attach profile" error` from AWS] have been added.
-* The link:{docurl}single-html/caasp-deployment/#_glossary[Glossary] was reintroduced to all our guides.
+* A note about using the `--non-interactive-include-reboot-patches` was added to the link:https://documentation.suse.com/suse-caasp/4.2//single-html/caasp-admin/#disabling-automatic-updates[Admin Guide].
+* Instructions on how to update Dex have been enhanced. For details, see link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_sec.admin.security.rbac.update[the Admin Guide].
+* We updated the air gapped deployment with a new diagram. See the link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#airgap-concepts[Admin Guide].
+* We added an example on how to set up link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/caasp-admin.html#recording_rules_configuration_example[Prometheus Recording Rules].
+* link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/caasp-admin.html#_aws_deployment_fails_with_cannot_attach_profile_error[Instructions on how to troubleshoot the `"cannot attach profile" error` from AWS] have been added.
+* The link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#_glossary[Glossary] was reintroduced to all our guides.
 * Various other fixes and improvements (Refer to: https://github.com/SUSE/doc-caasp/releases).
 
 [[known-issues-420]]

--- a/adoc/release-4.2.1.adoc
+++ b/adoc/release-4.2.1.adoc
@@ -17,27 +17,27 @@ In version 1.6.6 Cilium uses Custom Resource Definition (CRD) and ConfigMap poin
 The Metrics Server now supports monitoring of *CPU* and *memory* of a pod or node.  You can use commands `kubectl top nodes` get status for node and use `kubectl top pods` to get status for pod.
 This information can also be used and show in be Prometheus or Grafana.
 
-For detailed instructions please see link:{docurl}single-html/caasp-admin/#_monitoring_certificates[the Administration Guide]
+For detailed instructions please see link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_monitoring_certificates[the Administration Guide]
 
 === Cert Status Checker
 
 The Cert Status Checker is a new feature, which exposes a cluster-wide certificates status.
 It uses the monitoring stack (Prometheus and Grafana) to receive alerts by Prometheus Alert manager and monitor certificate status on the Grafana dashboard.
 
-For detailed instructions please see link:{docurl}single-html/caasp-admin/#_monitoring_certificates[the Administration Guide]
+For detailed instructions please see link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_monitoring_certificates[the Administration Guide]
 
 === VSphere VCP
 
 * Allow Kubernetes pods to use VMware vSphere Virtual Machine Disk (VMDK) volumes as persistent storage.
 
-For detailed instructions please see link:{docurl}single-html/caasp-admin/#_vsphere_storage[the Administration Guide]
+For detailed instructions please see link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_vsphere_storage[the Administration Guide]
 
 === Required Actions
 
 * To migrate from etcd to CRD in case of upgrade, follow the steps described in the link:https://docs.cilium.io/en/v1.6/install/upgrade/#upgrade-notes[official Cilium documentation].
-* Run `skuba addons upgrade apply` to upgrade Cilium to version 1.6.6. See information about a possible warning, which might appear during the upgrade in link:{docurl}single-html/caasp-admin/#_generating_an_overview_of_available_addon_updates[the Administration Guide].
+* Run `skuba addons upgrade apply` to upgrade Cilium to version 1.6.6. See information about a possible warning, which might appear during the upgrade in link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_generating_an_overview_of_available_addon_updates[the Administration Guide].
 
-* In order to update `skuba` to apply the latest fixes, you also need to update the admin workstation. For detailed instructions, see link:{docurl}single-html/caasp-admin/#_update_management_workstation[this section in the Admin Guide].
+* In order to update `skuba` to apply the latest fixes, you also need to update the admin workstation. For detailed instructions, see link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_update_management_workstation[this section in the Admin Guide].
 
 === Bugs Fixed in 4.2.1 since 4.2.0
 
@@ -48,13 +48,13 @@ For detailed instructions please see link:{docurl}single-html/caasp-admin/#_vsph
 [[docs-changes-421]]
 === Documentation Changes
 
-* Added instructions how to enable and configure link:{docurl}single-html/caasp-admin/#_audit_log[Kubernetes Audit Log].
-* Updated Network Policy administration with Cilium at link:{docurl}single-html/caasp-admin/#_network_policies[Network Policies].
-* Added instructions for deployment of Cilium Network policies with Envoy at link:{docurl}single-html/caasp-deployment/#_cilium_network_policy_config_examples[Cilium Network Policy Config Examples].
-* Added link:{docurl}single-html/caasp-deployment/#_networking_whitelist[Networking Whitelist] to deployment guide requirements.
-* Restructured the link:{docurl}single-html/caasp-admin/#_cluster_disaster_recovery[Disaster Recovery] chapter.
-* Added instruction for link:{docurl}single-html/caasp-deployment/#cluster.bootstrap.vcp[vSphere Cloud Provider Integration].
-* Fixed the location for the link:{docurl}single-html/caasp-admin/#_flexvolume_configuration[flexvolume driver] in the documentation.
+* Added instructions how to enable and configure link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_audit_log[Kubernetes Audit Log].
+* Updated Network Policy administration with Cilium at link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_network_policies[Network Policies].
+* Added instructions for deployment of Cilium Network policies with Envoy at link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#_cilium_network_policy_config_examples[Cilium Network Policy Config Examples].
+* Added link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#_networking_whitelist[Networking Whitelist] to deployment guide requirements.
+* Restructured the link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_cluster_disaster_recovery[Disaster Recovery] chapter.
+* Added instruction for link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-deployment/#cluster.bootstrap.vcp[vSphere Cloud Provider Integration].
+* Fixed the location for the link:https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_flexvolume_configuration[flexvolume driver] in the documentation.
 * Various other fixes and improvements, refer to: https://github.com/SUSE/doc-caasp/releases/tag/release-4.2.1
 
 [[known-issues-421]]

--- a/adoc/release-5.0.0.adoc
+++ b/adoc/release-5.0.0.adoc
@@ -8,6 +8,6 @@
 
 ===== Updated Kubernetes
 
-=== Updating to {productname} {productmajor} 
+=== Updating to {productname} {productmajor}
 
 === Known Issues

--- a/adoc/release-5.0.0.adoc
+++ b/adoc/release-5.0.0.adoc
@@ -1,0 +1,13 @@
+== Changes in 5.0.0
+
+=== What Is New
+
+==== Base Operating System Is Now {slsa} 15 SP2
+
+==== Changes to the {kube} Stack
+
+===== Updated Kubernetes
+
+=== Updating to {productname} {productmajor} 
+
+=== Known Issues


### PR DESCRIPTION
I bumped the product version attributes to 5.0.0 and then realized that since the `docurl ` attribute also includes {productmajor} and {productminor}, bumping the version will mess up all our documentation links. So I fixed that by removing {docurl} and replacing it with the actual link. Since I feel that {docurl} has been more trouble than help in the past, I suggest that we either remove it completely or only use it without the version numbers as `https://documentation.suse.com/suse-caasp/`. 