### PR TITLE
Added release-notes for CaaSP 4.2.2

### DIFF
--- a/adoc/release-4.2.1.adoc
+++ b/adoc/release-4.2.1.adoc
@@ -2,11 +2,11 @@
 
 === Cilium Update to 1.6.6 with Envoy
 
-{productname} 4.2.1 comes with an update of Cilium from version 1.5.3 to *version 1.6.6*.
-For a detailed list of all the changes in this most current version, see the link:https://github.com/cilium/cilium/blob/v1.6.6/CHANGELOG.md[Cilium Changelog].
-The update also provides link:https://www.envoyproxy.io/[Envoy] (open source edge and service proxy) support for Cilium.
-Envoy and its dependencies are packaged in link:https://www.envoyproxy.io/docs/envoy/v1.12.2/[version 1.12.2].
-In version 1.6.6 Cilium uses Custom Resource Definition (CRD) and ConfigMap points on etcd have been removed.
+- {productname} 4.2.1 comes with an update of Cilium from version 1.5.3 to *version 1.6.6*.
+   For a detailed list of all the changes in this most current version, see the link:https://github.com/cilium/cilium/blob/v1.6.6/CHANGELOG.md[Cilium Changelog].
+- The update also provides link:https://www.envoyproxy.io/[Envoy] (open source edge and service proxy) support for Cilium.
+- Envoy and its dependencies are packaged in link:https://www.envoyproxy.io/docs/envoy/v1.12.2/[version 1.12.2].
+- In version 1.6.6 Cilium uses Custom Resource Definition (CRD) and ConfigMap points on etcd have been removed.
 
 === `skuba`
 

--- a/adoc/release-4.2.2.adoc
+++ b/adoc/release-4.2.2.adoc
@@ -1,0 +1,24 @@
+== Changes in 4.2.2
+
+=== Deprecations in 4.2.2
+None
+
+=== Required Actions
+
+* Run `skuba addons upgrade apply` to update Cilium images to rev5 which has the bug fixes to be installed.
+* In order to use the latest `skuba` fixes, you need to update the admin workstation. For detailed instructions, see link: https://documentation.suse.com/suse-caasp/4.2/single-html/caasp-admin/#_update_management_workstation
+
+=== Bugs Fixed in 4.2.2 since 4.2.0
+
+* link:https://bugzilla.suse.com/show_bug.cgi?id=1173039[bsc#1173039] [cilium] - cilium fails to start when IPv6 is disabled
+* link:https://bugzilla.suse.com/show_bug.cgi?id=1173039[bsc#1173055] [skuba]  - dex to AD - error 401 after successful login
+* link:https://bugzilla.suse.com/show_bug.cgi?id=1173039[bsc#1146991] [skuba]  - BPF filesystem is not mounted when cilium pods are restarted
+
+[[docs-changes-422]]
+=== Documentation Changes
+
+[[known-issues-422]]
+=== Known Issues
+
+* Kubeproxy is not fully deprecated since envoyproxy requires support of Linux Kernel 5.3 and upwards.
+


### PR DESCRIPTION
Adding release for bugfixes of Cilium and Skuba:

* link:https://bugzilla.suse.com/show_bug.cgi?id=1173039[bsc#1173039] [cilium] - cilium fails to start when IPv6 is disabled
* link:https://bugzilla.suse.com/show_bug.cgi?id=1173055[bsc#1173055] [skuba]  - dex to AD - error 401 after successful login
* link:https://bugzilla.suse.com/show_bug.cgi?id=1146991[bsc#1146991] [skuba]  - BPF filesystem is not mounted when cilium pods are restarted

Tracked through https://github.com/SUSE/avant-garde/issues/1744