### PR TITLE
adoc: added a reference to the migration to 4.5.0 page

### DIFF
--- a/adoc/release-4.5.0.adoc
+++ b/adoc/release-4.5.0.adoc
@@ -42,7 +42,7 @@ From {productname} version 4.5.0 onwards, {kube} packages are built with new pac
 * `kubernetes-1.18-proxy-1.18.6-1.1.x86_64.rpm`
 * `kubernetes-1.18-scheduler-1.18.6-1.1.x86_64.rpm`
 
-In {productname} {kube} packages use the `kubernetes-1.18-name` pattern. The reason for this is because the link:https://kubic.opensuse.org/[openSUSE Kubic] project already uses the pattern `kubernetes1.18-name` but with different package (dependency) semantics underneath. 
+In {productname} {kube} packages use the `kubernetes-1.18-name` pattern. The reason for this is because the link:https://kubic.opensuse.org/[openSUSE Kubic] project already uses the pattern `kubernetes1.18-name` but with different package (dependency) semantics underneath.
 
 Having two identically named packages from SUSE (one from {productname}, one from  Kubic) with different semantics could lead to confusion and conflicts/problems with installation of the software from either project.
 
@@ -144,3 +144,7 @@ The installer for the Helm 2to3 plugin is written to pull the plugin from the of
 This could cause a problem in an air-gapped {productname} installation where an open internet connection is not available.
 
 The simplest workaround is to move the management system (such as a laptop) out of the internal network, install the plugin, then move back in to perform the migration.
+
+== Migrating to 4.5.0
+
+If you are coming from the latest release, just follow the instructions described link:{docurl}single-html/caasp-admin/#caasp-migrate-4.5[here]. Otherwise, if you are coming from older releases, you will have to upgrade to the previous {productname} release first, and then follow the link above.


### PR DESCRIPTION
See SUSE/doc-caasp#979
See SUSE/avant-garde#1918

Signed-off-by: Miquel Sabaté Solà <msabate@suse.com>